### PR TITLE
PP standard throws undefined method if PDT not on

### DIFF
--- a/includes/modules/payment/paypal_standard.php
+++ b/includes/modules/payment/paypal_standard.php
@@ -596,7 +596,7 @@
 
           $this->_app->log('PS', $pptx_params['cmd'], ($result == 'VERIFIED') ? 1 : -1, $pptx_params, $result, (OSCOM_APP_PAYPAL_PS_STATUS == '1') ? 'live' : 'sandbox');
         } else {
-          $details = $this->_app->getApiResult('PS', 'GetTransactionDetails', array('TRANSACTIONID' => $_GET['tx']), (OSCOM_APP_PAYPAL_DP_STATUS == '1') ? 'live' : 'sandbox');
+          $details = $this->_app->getApiResult('APP', 'GetTransactionDetails', array('TRANSACTIONID' => $_GET['tx']), (OSCOM_APP_PAYPAL_PS_STATUS == '1') ? 'live' : 'sandbox');
 
           if ( in_array($details['ACK'], array('Success', 'SuccessWithWarning')) ) {
             $result = 'VERIFIED';


### PR DESCRIPTION
if installed but not enabled... or installed and enabled!